### PR TITLE
修复获取 IP 地址时包含 Docker IP 和多重换行的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
 4 在`~/.condarc`中添加`changeps1: False`
 
+`conda config --set changeps1 False`
+
 # myys_v2.zsh-theme
 
 ![在这里插入图片描述](https://img-blog.csdnimg.cn/55bf1c99ca7e462a807d86eaa2509091.png)

--- a/README.md
+++ b/README.md
@@ -31,3 +31,17 @@
 - 2019.9.12：修复BUG（连续使用Tab导致当前命令行乱码）
 - 2021.11.29：更新V2版本，优化界面，显示IP地址。
 - 2024.11.6：修复BUG（IP地址获取出错）
+
+```bash
+git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
+git clone https://github.com/marlonrichert/zsh-autocomplete ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autocomplete
+plugins=(
+     git
+     zsh-autocomplete
+     zsh-autosuggestions
+     zsh-syntax-highlighting
+     z
+     # autocd
+)
+```

--- a/myys_v2.zsh-theme
+++ b/myys_v2.zsh-theme
@@ -56,7 +56,16 @@ ys_hg_prompt_info() {
 
 local exit_code="%(?,,C:%{$fg[red]%}%?%{$reset_color%})"
 
-ipStr=$(ip addr show | grep 'inet ' | grep -v '127.0.0.1' | awk '{print $2}' | cut -d '/' -f1)
+ipStr=$(
+  ip addr show                        \
+    | grep 'inet '                   \
+    | grep -v '127.0.0.1'            \
+    | grep -v 'docker'               \
+    | awk '{print $2}'               \
+    | cut -d '/' -f1                 \
+    | paste -sd '|' -
+)
+
 # Prompt format:
 #
 # PRIVILEGES USER @ MACHINE in DIRECTORY on git:BRANCH STATE [TIME] C:LAST_EXIT_CODE


### PR DESCRIPTION
### 描述
在当前的 Zsh 配置脚本中，为了获取本地网络 IP，使用了如下命令：

```bash
ipStr=$(ip addr show | grep 'inet ' | grep -v '127.0.0.1' | awk '{print $2}' | cut -d '/' -f1)
```

但是该命令存在以下问题：

1. **包含 Docker 网卡 IP**  
   当机器上同时安装了 Docker 时，会出现 `docker0` 的 IP 地址（通常为 `172.17.0.x`）也被获取并展示。  
2. **多 IP 时换行**  
   如果存在多个有效网卡（例如有线、无线等），会返回多行 IP 地址，而提示符中出现意外的换行。

### 修复内容

1. **过滤 Docker 网卡**  
   通过 `grep -v 'docker'` 去除 Docker 网卡的记录。  
2. **多个 IP 用 `|` 拼接**  
   使用 `paste -sd '|' -` 将多条 IP 记录拼接到一行中，并用 `|` 分隔，避免多行输出造成提示符中断。
